### PR TITLE
 set minify to false in react-native cli

### DIFF
--- a/src/lib/react-native-utils.ts
+++ b/src/lib/react-native-utils.ts
@@ -291,6 +291,8 @@ export function runReactNativeBundleCommand(
         entryFile,
         '--platform',
         platform,
+        '--minify',
+        'false'
     ]);
 
     if (sourcemapOutput) {


### PR DESCRIPTION
if minify set true react change class's names to shorter name.
Some package like typeorm (in migrations) need Specific class name to work.
so we need set minify false to react don't change variables names.